### PR TITLE
Platt scaling name

### DIFF
--- a/pica/ClassificationResults.py
+++ b/pica/ClassificationResults.py
@@ -211,12 +211,12 @@ class ClassificationResults:
 		return "\n".join(sout)
 		
 	def print_classification_log(self):
-		print "Organism\tTrue\tPredicted\tProbability"
+		print "Organism\tTrue\tPredicted\tPrediction_Confidence"
 		for c in self.classifications_list:
 			print c
 			
 	def print_classification_log_predictedOnly(self):
-		print "Organism\tPredicted\tProbability"
+		print "Organism\tPredicted\tPrediction_Confidence"
 		for c in self.classifications_list:
 			print "\t".join(c.getSpeciesPrediction())
 


### PR DESCRIPTION
When test.py is executed, the result of Platt scaling is called "Probability". The Platt scaling returns a value between 0 and 1, but it is not a probability in the statistical sense. In the PhenDB project of CUBE, this value is therefore called "Prediction_Confidence". In my opinion, this name should also be used in PICA itself. 