### PR TITLE
MAINT refer to phenotrex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # PICA
+
+Please checkout the new `phenotrex` package, which succeeds PICA:
+https://github.com/univieCUBE/phenotrex
+
+It comes with a considerable number of improvements
+
+ - Builds upon the battle-tested SciPy stack (`scikit-learn`, `pandas`, etc.)
+ - More easily extensible
+ - New classifiers (e.g. XGboost)
+ - Test-driven development
+ - Supports Python 3.7 and higher
+ - Available from PyPI: `$ pip install phenotrex`


### PR DESCRIPTION
Let's redirect (potential) PICA users to the new `phenotrex` package
by pointing to the new repo in the readme on Github.

I think it makes sense to include some information about the improvements
in `phenotrex` compared to PICA. Please feel free to add any, if something
is missing in the list.